### PR TITLE
Set default server name

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -2,7 +2,7 @@
     "default_server_config": {
         "m.homeserver": {
             "base_url": "https://__DEFAULT_HOME_SERVER__",
-            "server_name": "matrix.org"
+            "server_name": "__DEFAULT_HOME_SERVER__"
         },
         "m.identity_server": {
             "base_url": "https://vector.im"


### PR DESCRIPTION
Quick fix for #145 for setting the default server name to the homeserver URL without any scheme

## Solution

Use the templating to set the `server_name` to `__DEFAULT_HOME_SERVER__`.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested: not yet

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
